### PR TITLE
www cname => non-www

### DIFF
--- a/zones/thinkingliquid.org
+++ b/zones/thinkingliquid.org
@@ -21,7 +21,7 @@ $ORIGIN thinkingliquid.org.
 ; Servers
 
 ; Services
-www		DYNA	geoip!mw
+www		CNAME	@
 
 ; load balancers
 


### PR DESCRIPTION
currently going to www.thinkingliquid.org redirects to meta with an SSL error