### PR TITLE
Add phab.miraheze.wiki

### DIFF
--- a/zones/miraheze.wiki
+++ b/zones/miraheze.wiki
@@ -24,6 +24,7 @@ $ORIGIN miraheze.wiki.
 
 ; Services
 status		CNAME	stats.uptimerobot.com.
+phab  		CNAME	phabricator.miraheze.org.
 
 ; load balancers
 


### PR DESCRIPTION
Ref [T1752](https://phabricator.miraheze.org/T1752). Adds a file domain as a CNAME.