### PR TITLE
Update dns health check to check every 10s and up timeout to 8s

### DIFF
--- a/config
+++ b/config
@@ -17,8 +17,8 @@ service_types => {
 		up_thresh => 3,
 		ok_thresh => 3,
 		down_thresh => 3,
-		interval => 7,
-		timeout => 5,
+		interval => 10,
+		timeout => 8,
 	}
 }
 


### PR DESCRIPTION
This matches our varnish config. Seeing as cp* is spread around.