### PR TITLE
cache: Switch to cp6 from cp4

### DIFF
--- a/config
+++ b/config
@@ -38,15 +38,15 @@ plugins => {
 		maps => {
 			generic-map => {
 				geoip2_db => /usr/share/GeoIP/GeoLite2-Country.mmdb
-				datacenters => [cp3 cp4 cp8]
+				datacenters => [cp3 cp6 cp8]
 				map => {
-					AF => [cp4, cp3, cp8],
-					AS => [cp3, cp4, cp8],
-					EU => [cp4, cp8, cp3],
-					NA => [cp8, cp4, cp3],
-					OC => [cp3, cp8, cp4],
-					SA => [cp8, cp4, cp3],
-					default => [cp4, cp8, cp3],
+					AF => [cp6, cp3, cp8],
+					AS => [cp3, cp6, cp8],
+					EU => [cp6, cp8, cp3],
+					NA => [cp8, cp6, cp3],
+					OC => [cp3, cp8, cp6],
+					SA => [cp8, cp6, cp3],
+					default => [cp6, cp8, cp3],
 				},
 			},
 		},
@@ -59,9 +59,9 @@ plugins => {
 						addrs_v4 => 128.199.139.216,
 						addrs_v6 => 2400:6180:0:d0::403:f001,
 					}
-					cp4 => {
- 						addrs_v4 => 81.4.109.133,
- 						addrs_v6 => 2a00:d880:5:8ea::ebc7,
+					cp6 => {
+ 						addrs_v4 => 51.77.107.210,
+ 						addrs_v6 => 2001:41d0:800:1056::2,
  					}
 					cp8 => {
 						addrs_v4 => 51.161.32.127,


### PR DESCRIPTION
cp6 still uses mw[123] so this is a safe switch in so far as no majour performance degradation.