### PR TITLE
Fallover cp6 to cp7

### DIFF
--- a/config
+++ b/config
@@ -26,9 +26,6 @@ plugins => {
 	weighted => {
 		multi = false
 		service_types = up
-		cache => {
-			cp7 = [ cp7.miraheze.org., 1 ]
-		}
 		services => {
 			services1 = [ services1.miraheze.org., 1 ]
 			services2 = [ services2.miraheze.org., 1 ]
@@ -38,15 +35,15 @@ plugins => {
 		maps => {
 			generic-map => {
 				geoip2_db => /usr/share/GeoIP/GeoLite2-Country.mmdb
-				datacenters => [cp3 cp6 cp8]
+				datacenters => [cp3 cp7 cp8]
 				map => {
-					AF => [cp6, cp3, cp8],
-					AS => [cp3, cp6, cp8],
-					EU => [cp6, cp8, cp3],
-					NA => [cp8, cp6, cp3],
-					OC => [cp3, cp8, cp6],
-					SA => [cp8, cp6, cp3],
-					default => [cp6, cp8, cp3],
+					AF => [cp7, cp3, cp8],
+					AS => [cp3, cp7, cp8],
+					EU => [cp7, cp8, cp3],
+					NA => [cp8, cp7, cp3],
+					OC => [cp3, cp8, cp7],
+					SA => [cp8, cp7, cp3],
+					default => [cp7, cp8, cp3],
 				},
 			},
 		},
@@ -59,9 +56,9 @@ plugins => {
 						addrs_v4 => 128.199.139.216,
 						addrs_v6 => 2400:6180:0:d0::403:f001,
 					}
-					cp6 => {
- 						addrs_v4 => 51.77.107.210,
- 						addrs_v6 => 2001:41d0:800:1056::2,
+					cp7 => {
+ 						addrs_v4 => 51.89.160.142,
+ 						addrs_v6 => 2001:41d0:800:105a::10,
  					}
 					cp8 => {
 						addrs_v4 => 51.161.32.127,


### PR DESCRIPTION
The i/o on cloud1 is quite high, switching to cp7 has lower i/o so cp6 load should come down.