### PR TITLE
Up timeout to 10

### DIFF
--- a/config
+++ b/config
@@ -18,7 +18,7 @@ service_types => {
 		ok_thresh => 3,
 		down_thresh => 3,
 		interval => 7,
-		timeout => 5,
+		timeout => 10,
 	}
 }
 


### PR DESCRIPTION
Everyday our DNS check reports stuff like "PROBLEM - wiki.bullshit.systems - DNS on sslhost is CRITICAL: DNS CRITICAL - expected '2001:41d0:800:1056::2,2001:41d0:800:105a::10,51.77.107.210,51.89.160.142' but got '2001:41d0:800:1056::2,51.77.107.210,51.89.160.142", i've checked and i see it depools the cp. Upping the timeout may make it unlikely that it is depooled.