### PR TITLE
add 2 new subdomains for MirahezeBots

### DIFF
--- a/zones/miraheze.wiki
+++ b/zones/miraheze.wiki
@@ -47,6 +47,9 @@ icinga.bots		A	198.255.68.179
 icinga.bots		AAAA	2001:49f0:d04c:4:2:1:0:0
 phabdigests.bots	A	82.145.63.172
 support.bots		A	82.145.63.172
+sopel.bots		A	198.255.68.179
+sopel.bots		AAAA	2001:49f0:d04c:4:2:1:0:0
+phab-storage.bots	A	82.145.63.172
 
 
 ; Bots - Servers


### PR DESCRIPTION
sopel.bots is for serving files generated by .help
phab-storage.bots is to be used as an alternate file domain for phab.bots.miraheze.wiki