### PR TITLE
miraheze.org: add my google sites key

### DIFF
--- a/zones/miraheze.org
+++ b/zones/miraheze.org
@@ -50,6 +50,7 @@ _dmarc		TXT	"v=DMARC1; p=reject; rua=mailto:dmarc@miraheze.org; ruf=mailto:dmarc
 
 ; Miscellaneous
 miraheze.org.   TXT     "google-site-verification=7WSUzjqZswhi5NfG45XJQ46IY_nKdaUhkSD7MN4wY94"
+miraheze.org.   TXT     'google-site-verification=AnS3Zr6OAWZIn883-jBaqDU2T0aTwnhc6jMjVbzZ8fM"
 miraheze.org.	TXT	"_globalsign-domain-verification=VSF3i19MYIR4UsdgiIyOqPxNXKxpfkWK0jbiKG8VnK"
 
 ; m.miraheze.org challenge (acme)


### PR DESCRIPTION
I'm already delegated by SPF for access, use a TXT key as SPF is Single Point of Failure for this at moment