### PR TITLE
Add www to famedata.org zone

### DIFF
--- a/zones/famedata.org
+++ b/zones/famedata.org
@@ -28,6 +28,7 @@ $ORIGIN famedata.org.
 ; Servers
 
 ; Services
+www		DYNA	geoip!cp
 pop		CNAME	us2.pop.mailhostbox.com.
 imap		CNAME	us2.imap.mailhostbox.com.
 smtp		CNAME	us2.smtp.mailhostbox.com.


### PR DESCRIPTION
This is being redirected via SSL, so necessary to avoid icinga warnings, and for it to actually work.