### PR TITLE
Add ldap cname

### DIFF
--- a/zones/miraheze.org
+++ b/zones/miraheze.org
@@ -134,6 +134,7 @@ webmail		DYNA	geoip!cp
 graylog		CNAME	graylog121
 deployment      CNAME   mwtask141
 mwtask          CNAME   mwtask141
+ldap		CNAME	ldap141
 reports         DYNA	geoip!cp
 
 ; Load Balancers


### PR DESCRIPTION
So it can be used in replace of server names in services, so if it is ever changed again, it won't lock login out if not updated in services configs, and so that so much does not have to be changed for it.