### PR TITLE
Fix eurocom.wiki zone

### DIFF
--- a/zones/eurocom.wiki
+++ b/zones/eurocom.wiki
@@ -1,5 +1,5 @@
 $TTL 300
-$ORIGIN eurocom.wiki
+$ORIGIN eurocom.wiki.
 
 @		SOA ns1.miraheze.org. hostmaster.miraheze.org. (
 		20230520000001   ; serial


### PR DESCRIPTION
It's currently not working, I'm guessing this missing period is why.