### PR TITLE
Add swiftproxy161/171 to miraheze.org for alias

### DIFF
--- a/zones/miraheze.org
+++ b/zones/miraheze.org
@@ -125,4 +125,8 @@ swift-lb	DYNA	weighted!swift
 ; wikitide (cloud17)
 ldap   		AAAA	2602:294:0:b23::103
 
+; swiftproxy161/171 wikitide servers alias
+swiftproxy161   	AAAA	2602:294:0:b13::109
+swiftproxy171   	AAAA	2602:294:0:b23::109
+
 ; Other


### PR DESCRIPTION
This is so our cert can match the url.