### PR TITLE
Setup CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   checkconf-job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: gdnsd checkconf
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: gdnsd checkconf
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+
+jobs:
+  checkconf-job:
+    runs-on: ubuntu-latest
+    name: A job that runs gdnsd checkconf on this repository
+    steps:
+      - uses: actions/checkout@v4
+      - id: checkconf
+        uses: miraheze/dns-check-action@master
+        with:
+          geoip2-directory: '/usr/share/GeoIP'
+          geoip2-filename: 'GeoLite2-Country.mmdb'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: checkconf
-        uses: miraheze/dns-check-action@master
+        uses: miraheze/dns-check-action@v1
         with:
           geoip-directory: '/usr/share/GeoIP'
           geoip-filename: 'GeoLite2-Country.mmdb'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,11 @@ on:
 jobs:
   checkconf-job:
     runs-on: ubuntu-latest
-    name: A job that runs gdnsd checkconf on this repository
+    name: gdnsd checkconf
     steps:
       - uses: actions/checkout@v4
       - id: checkconf
         uses: miraheze/dns-check-action@master
         with:
-          geoip2-directory: '/usr/share/GeoIP'
-          geoip2-filename: 'GeoLite2-Country.mmdb'
+          geoip-directory: '/usr/share/GeoIP'
+          geoip-filename: 'GeoLite2-Country.mmdb'


### PR DESCRIPTION
Uses miraheze/dns-check-action

Requires Ubuntu 24.04 instead of latest (22.04 as of writing) because 22.04 does not have gdnsd.