### PR TITLE
rainverse.wiki: Add _servfail-challenge

### DIFF
--- a/zones/rainverse.wiki
+++ b/zones/rainverse.wiki
@@ -36,3 +36,4 @@ s		CNAME	downscale
 
 ; Other
 _github-pages-challenge-BlankEclair.shrink	TXT	"764b61c4c870465c3e4e8ffc9e6985"
+_servfail-challenge	TXT	"0xS73TXNBP3CdXuNi1tRIIJQI."


### PR DESCRIPTION
We're moving to Project SERVFAIL, which requires us to set this record to gracefully add our zone to our account